### PR TITLE
kube transition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
 .PHONY: % dist-clean dist make-zip svn test check fix
 
 VERSION := $(shell sed -n 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*\([0-9][0-9.]*\).*/\1/p' image-cdn.php)
-FILE := image-cdn-$(VERSION).zip
+SLUG := image-cdn
+FILE := $(SLUG)-$(VERSION).zip
 
 dist-clean:
-	rm -rf dist/image_cdn
+	rm -rf dist/$(SLUG)
 
 dist: dist-clean make-zip
 
 make-zip:
+	@test -f config/APIData.php || { echo "ERROR: config/APIData.php is missing; the built plugin will not work. Create it from vendor/imageengine/php-sdk/config/APIData.sample.php"; exit 1; }
 	rm dist/${FILE} || echo -n ""
-	mkdir -p dist/image_cdn
-	cp -v -r *.php *.txt imageengine assets templates dist/image_cdn/
-	cd dist && zip -9 -r ${FILE} image_cdn
-	rm -rf dist/image_cdn
+	mkdir -p dist/$(SLUG)
+	cp -v -r *.php *.txt composer.json imageengine assets templates config vendor dist/$(SLUG)/
+	cd dist && zip -9 -r ${FILE} $(SLUG)
+	rm -rf dist/$(SLUG)
 
 test:
 	vendor/bin/phpunit -vvv -c phpunit-standalone.xml.dist

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: % dist-clean dist make-zip svn test check fix
 
-FILE := image-cdn-0.0.0.zip
+VERSION := $(shell sed -n 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*\([0-9][0-9.]*\).*/\1/p' image-cdn.php)
+FILE := image-cdn-$(VERSION).zip
 
 dist-clean:
 	rm -rf dist/image_cdn

--- a/image-cdn.php
+++ b/image-cdn.php
@@ -16,14 +16,14 @@
  * Requires PHP:      7.4
  * Text Domain:       image-cdn
  * License:           GPLv2 or later
- * Version:           1.2.8
+ * Version:           1.2.9
  */
 
 // Update this when you update "Requires at least" above!
 define( 'IMAGE_CDN_MIN_WP', '5.3' );
 
 // Update this when you update the "Version" above!
-define( 'IMAGE_CDN_VERSION', '1.2.8' );
+define( 'IMAGE_CDN_VERSION', '1.2.9' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );

--- a/imageengine/class-imagecdn.php
+++ b/imageengine/class-imagecdn.php
@@ -572,8 +572,8 @@ class ImageCDN {
 					?>
 				</p>
 				<ol>
-					<li><?php esc_html_e( 'Claim your delivery address by signing up, or log in if you already have an account.', 'image-cdn') ?></li>
-					<li><?php esc_html_e( 'Delivery address appears in the Setup tab below.', 'image-cdn') ?></li>
+					<li><?php esc_html_e( 'Create an ImageEngine Sandbox account or log in below, or enter your ImageEngine Kube delivery address in the Setup tab.', 'image-cdn') ?></li>
+					<li><?php esc_html_e( 'Your delivery address appears in the Setup tab below.', 'image-cdn') ?></li>
 					<?php
 					if ( ! $options['enabled'] ) {
 						?>

--- a/imageengine/class-settings.php
+++ b/imageengine/class-settings.php
@@ -441,7 +441,7 @@ class Settings {
 		}
 
 		try {
-			$response = self::client()->register( $_POST['register_username'], $_POST['register_password'], $_POST['register_plan'] );
+			$response = self::client()->register( $_POST['register_username'], $_POST['register_password'], 'free' );
 
 			$message = ImageCDN::update_delivery_address( $response );
 			if ( is_string( $message ) ) {
@@ -486,7 +486,7 @@ class Settings {
 		}
 
 		try {
-			$response = self::client()->login( $_POST['login_username'], $_POST['login_password'] );
+			$response = self::client()->login( $_POST['login_username'], $_POST['login_password'], 'free' );
 
 			$message = ImageCDN::update_delivery_address( $response );
 			if ( is_string( $message ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,11 @@ The following are the steps to install the Image CDN plugin.
 
 
 == Changelog ==
+= 1.2.9 =
+* Replaced the SaaS 30-day trial signup with a single ImageEngine Sandbox account for evaluation
+* Registration and login now use the Sandbox (free) plan
+* Updated onboarding copy for ImageEngine Kube delivery addresses
+
 = 1.2.8 =
 * Kube compatibility
 * Version update

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -146,15 +146,14 @@ use ImageEngine\Settings;
 			?>
 			<nav class="nav-tab-wrapper wp-clearfix">
 				<a href="#" class="nav-tab <?php echo $tabA == "register" ? "nav-tab-active" : "" ?>"
-				   data-tab="register"><?php esc_html_e("Claim your Delivery Address", "image-cdn") ?></a>
+				   data-tab="register"><?php esc_html_e("Create an ImageEngine Sandbox", "image-cdn") ?></a>
 				<a href="#" class="nav-tab <?php echo $tabA == "login" ? "nav-tab-active" : "" ?>"
-				   data-tab="login"><?php esc_html_e("Log in if you already have a Delivery Address", "image-cdn") ?></a>
+				   data-tab="login"><?php esc_html_e("Log in if you already have an account", "image-cdn") ?></a>
 			</nav>
 
 			<div class="tab-content <?php echo $tabA == "register" ? "active" : "" ?>" data-tab="register">
 
-				<p><?php echo sprintf(__("If you don't already have an ImageEngine account, claim your Delivery Address
-					for %s and get optimized in minutes!", "image-cdn"), get_home_url()) ?></p>
+				<p><?php echo sprintf(__("Create a free ImageEngine Sandbox account to try ImageEngine on %s and get optimized in minutes. Already running ImageEngine Kube? Enter your delivery address in the Setup tab below, or log in to an existing account.", "image-cdn"), get_home_url()) ?></p>
 
 	<form method="post" action="/wp-admin/admin-post.php" >
 					<?php wp_nonce_field( 'image_cdn_register_nonce', '_wpnonce_register' ); ?>
@@ -168,26 +167,10 @@ use ImageEngine\Settings;
 
 					<div style="height: 1em;"></div>
 
-					<p style="margin-bottom: 10px;"><?php echo sprintf(__("Select plan: (%s)", "image-cdn"),
-						'<a href="https://imageengine.io/pricing/?utm_source=WP-plugin-settings&utm_medium=page&utm_term=wp-imageengine&utm_campaign=wp-imageengine" 
-										target="_blank">'.__("Learn more", "image-cdn").'</a>') ?></p>
-
-					<div style="margin-bottom: 5px;">
-						<label>
-							<input type="radio" name="register_plan" id="register_plan_trial" value="trial" checked="checked" />
-							<?php echo __("Free trial for 30 days, no commitments.", "image-cdn") ?>
-						</label>
-					</div>
-
-					<div style="margin-bottom: 18px;">
-						<label>
-							<input type="radio" name="register_plan" id="register_plan_free" value="free" />
-							<?php echo __("Free forever for developers (max 10GB per month, no commercial use)", "image-cdn") ?>
-						</label>
-					</div>
+					<p style="margin-bottom: 18px;"><?php echo __("The Sandbox is for evaluation (max 10GB per month, no commercial use).", "image-cdn") ?></p>
 
 					<button type="submit" name="register" id="register" class="button button-primary" onclick="this.disabled = true; this.parentElement.submit();"
-						><span class="button-loader"></span><?php esc_html_e("Register", "image-cdn") ?></button>
+						><span class="button-loader"></span><?php esc_html_e("Create Sandbox", "image-cdn") ?></button>
 				</form>
 			</div>
 			<div class="tab-content <?php echo $tabA == "login" ? "active" : "" ?>" data-tab="login">
@@ -195,7 +178,7 @@ use ImageEngine\Settings;
 				<?php if ( $options['url'] && $options['enabled'] ) : ?>
 					<p><?php echo __("If you have an ImageEngine account, log in here to view your stats!", "image-cdn") ?></p>
 				<?php else : ?>
-					<p><?php echo __("If you have an ImageEngine account, log in here to get your Delivery Address!", "image-cdn") ?></p>
+					<p><?php echo __("If you have an ImageEngine account, log in here to get your delivery address!", "image-cdn") ?></p>
 				<?php endif; ?>
 
 				<form method="post" action="/wp-admin/admin-post.php">


### PR DESCRIPTION
This pull request updates the Image CDN plugin to streamline the onboarding process. Registration and login flows now default to the Sandbox plan, and the user interface and onboarding copy have been updated to reflect this change.

**Plugin onboarding and registration updates:**

* Registration and login now always use the ImageEngine Sandbox (free) plan (`templates/settings.php`, `imageengine/class-settings.php`) [[1]](diffhunk://#diff-b3a77875bda59f2c2629f9c70326b1a6388d38c2685c7b34180217dc5bae4c56L171-R181) [[2]](diffhunk://#diff-6cbfa7ab837c127c20752514cbd0be53cca886e84812bdbd02c8a655586ba62fL444-R444) [[3]](diffhunk://#diff-6cbfa7ab837c127c20752514cbd0be53cca886e84812bdbd02c8a655586ba62fL489-R489).
* Updated onboarding and admin notice copy to clarify Sandbox usage, streamline instructions, and reference delivery addresses consistently (`templates/settings.php`, `imageengine/class-imagecdn.php`) [[1]](diffhunk://#diff-b3a77875bda59f2c2629f9c70326b1a6388d38c2685c7b34180217dc5bae4c56L149-R156) [[2]](diffhunk://#diff-b867885fa4ab01e958ba753140bdb35d15981e87955da43953e657524314295cL575-R576).

**Versioning and documentation:**

* Bumped plugin version to 1.2.9 in `image-cdn.php` and updated the changelog in `readme.txt` to document the new Sandbox onboarding flow [[1]](diffhunk://#diff-457aa41188dcbf8aa10c84ee71bb2abe1eadd90c6e66664a6cd393ecc6f6790dL19-R26) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R78-R82).
* Updated the `Makefile` to automatically set the ZIP filename based on the version in `image-cdn.php`.